### PR TITLE
Add Recent posts plugin

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -21,7 +21,7 @@ jobs:
           # https://github.com/lowlighter/metrics/blob/4eeea4c0cd385c2c0a8d56c6b03b6484f8c61bdd/action.yml
           base: header, activity, community, repositories
           # repositories_forks: yes
-          repositories_skipped: Jpsern/Jpsern, Jpsern/archive-tmh2, Jpsern/archive-tmh3, Jpsern/gh-pages-test, Jpsern/tkz
+          repositories_skipped: Jpsern/Jpsern, Jpsern/archive-tmh2, Jpsern/archive-tmh3, Jpsern/gh-pages-test, Jpsern/tkz, Jpsern/test-cypress
           plugin_pagespeed: yes
           plugin_pagespeed_url: https://jpsern.com
           plugin_pagespeed_token: ${{ secrets.PAGESPEED_TOKEN }}


### PR DESCRIPTION
### see
https://github.com/lowlighter/metrics/blob/master/source/plugins/posts/README.md

ブログの投稿でも出せるのかなと思ったらdev.toとhashnodeってサイトだけが対応していた。postsのプラグイン追加はやめ。別件でちょっと直した分だけマージする。